### PR TITLE
Guard hero slider setup when markup is absent

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,0 +1,189 @@
+'use strict';
+
+
+
+/**
+ * PRELOAD
+ * 
+ * loading will be end after document is loaded
+ */
+
+const preloader = document.querySelector("[data-preaload]");
+
+window.addEventListener("load", function () {
+  preloader.classList.add("loaded");
+  document.body.classList.add("loaded");
+});
+
+
+
+/**
+ * add event listener on multiple elements
+ */
+
+const addEventOnElements = function (elements, eventType, callback) {
+  if (!elements) return;
+
+  const targetElements = typeof elements.length === "number"
+    ? elements
+    : [elements];
+
+  for (let i = 0, len = targetElements.length; i < len; i++) {
+    const element = targetElements[i];
+
+    if (!element) continue;
+
+    element.addEventListener(eventType, callback);
+  }
+}
+
+
+
+/**
+ * NAVBAR
+ */
+
+const navbar = document.querySelector("[data-navbar]");
+const navTogglers = document.querySelectorAll("[data-nav-toggler]");
+const overlay = document.querySelector("[data-overlay]");
+
+const toggleNavbar = function () {
+  navbar.classList.toggle("active");
+  overlay.classList.toggle("active");
+  document.body.classList.toggle("nav-active");
+}
+
+addEventOnElements(navTogglers, "click", toggleNavbar);
+
+
+
+/**
+ * HEADER & BACK TOP BTN
+ */
+
+const header = document.querySelector("[data-header]");
+const backTopBtn = document.querySelector("[data-back-top-btn]");
+
+let lastScrollPos = 0;
+
+const hideHeader = function () {
+  const isScrollBottom = lastScrollPos < window.scrollY;
+  if (isScrollBottom) {
+    header.classList.add("hide");
+  } else {
+    header.classList.remove("hide");
+  }
+
+  lastScrollPos = window.scrollY;
+}
+
+window.addEventListener("scroll", function () {
+  if (window.scrollY >= 50) {
+    header.classList.add("active");
+    backTopBtn.classList.add("active");
+    hideHeader();
+  } else {
+    header.classList.remove("active");
+    backTopBtn.classList.remove("active");
+  }
+});
+
+
+
+/**
+ * HERO SLIDER
+ */
+
+const heroSlider = document.querySelector("[data-hero-slider]");
+const heroSliderItems = heroSlider
+  ? heroSlider.querySelectorAll("[data-hero-slider-item]")
+  : [];
+const heroSliderPrevBtn = heroSlider
+  ? heroSlider.querySelector("[data-prev-btn]")
+  : null;
+const heroSliderNextBtn = heroSlider
+  ? heroSlider.querySelector("[data-next-btn]")
+  : null;
+
+if (heroSlider && heroSliderItems.length && heroSliderPrevBtn && heroSliderNextBtn) {
+  let currentSlidePos = 0;
+  let lastActiveSliderItem = heroSliderItems[0];
+
+  const updateSliderPos = function () {
+    lastActiveSliderItem.classList.remove("active");
+    heroSliderItems[currentSlidePos].classList.add("active");
+    lastActiveSliderItem = heroSliderItems[currentSlidePos];
+  }
+
+  const slideNext = function () {
+    if (currentSlidePos >= heroSliderItems.length - 1) {
+      currentSlidePos = 0;
+    } else {
+      currentSlidePos++;
+    }
+
+    updateSliderPos();
+  }
+
+  const slidePrev = function () {
+    if (currentSlidePos <= 0) {
+      currentSlidePos = heroSliderItems.length - 1;
+    } else {
+      currentSlidePos--;
+    }
+
+    updateSliderPos();
+  }
+
+  heroSliderNextBtn.addEventListener("click", slideNext);
+  heroSliderPrevBtn.addEventListener("click", slidePrev);
+
+  /**
+   * auto slide
+   */
+
+  let autoSlideInterval;
+
+  const autoSlide = function () {
+    autoSlideInterval = setInterval(function () {
+      slideNext();
+    }, 7000);
+  }
+
+  const sliderNavButtons = [heroSliderNextBtn, heroSliderPrevBtn].filter(Boolean);
+
+  addEventOnElements(sliderNavButtons, "mouseover", function () {
+    clearInterval(autoSlideInterval);
+  });
+
+  addEventOnElements(sliderNavButtons, "mouseout", autoSlide);
+
+  window.addEventListener("load", autoSlide);
+}
+
+
+
+/**
+ * PARALLAX EFFECT
+ */
+
+const parallaxItems = document.querySelectorAll("[data-parallax-item]");
+
+let x, y;
+
+window.addEventListener("mousemove", function (event) {
+
+  x = (event.clientX / window.innerWidth * 10) - 5;
+  y = (event.clientY / window.innerHeight * 10) - 5;
+
+  // reverse the number eg. 20 -> -20, -5 -> 5
+  x = x - (x * 2);
+  y = y - (y * 2);
+
+  for (let i = 0, len = parallaxItems.length; i < len; i++) {
+    x = x * Number(parallaxItems[i].dataset.parallaxSpeed);
+    y = y * Number(parallaxItems[i].dataset.parallaxSpeed);
+    parallaxItems[i].style.transform = `translate3d(${x}px, ${y}px, 0px)`;
+  }
+
+});


### PR DESCRIPTION
## Summary
- ensure the hero slider only wires event listeners and auto-sliding when the slider items and controls are present
- filter slider navigation buttons before passing them to the shared addEventOnElements helper and make the helper skip null entries

## Testing
- Not run (project does not include automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cf411cc2ec832dbaa990b0ae676b19